### PR TITLE
소셜 회원 인증 서비스 도메인 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ bin/
 *.iws
 *.iml
 *.ipr
-out/
+/out/
 !**/src/main/**/out/
 !**/src/test/**/out/
 

--- a/src/main/java/petalk/mvp/auth/domain/AccessToken.java
+++ b/src/main/java/petalk/mvp/auth/domain/AccessToken.java
@@ -1,0 +1,21 @@
+package petalk.mvp.auth.domain;
+
+/**
+ * 소셜 로그인의 액세스 토큰을 나타내는 클래스입니다.
+ */
+public class AccessToken {
+
+    private String token;
+
+    private AccessToken(String token) {
+        this.token = token;
+    }
+
+    public static AccessToken from(String token) {
+        return new AccessToken(token);
+    }
+
+    public String getValue() {
+        return token;
+    }
+}

--- a/src/main/java/petalk/mvp/auth/domain/NaverAuthenticator.java
+++ b/src/main/java/petalk/mvp/auth/domain/NaverAuthenticator.java
@@ -1,0 +1,13 @@
+package petalk.mvp.auth.domain;
+
+/**
+ * 네이버 로그인 인증을 요청하는 클래스입니다.
+ */
+public class NaverAuthenticator implements SocialAuthenticator {
+    private AccessToken token;
+
+    @Override
+    public AccessToken getAccessToken(String code) {
+        return token;
+    }
+}

--- a/src/main/java/petalk/mvp/auth/domain/NaverSocialAuthUser.java
+++ b/src/main/java/petalk/mvp/auth/domain/NaverSocialAuthUser.java
@@ -1,0 +1,41 @@
+package petalk.mvp.auth.domain;
+
+import java.util.Objects;
+
+/**
+ * 네이버 유저의 정보를 나타내는 클래스입니다.
+ *
+ */
+public class NaverSocialAuthUser implements SocialAuthUser{
+    private SocialAuthId socialAuthId;
+
+    //== 생성 메소드 ==//
+    private NaverSocialAuthUser(SocialAuthId socialAuthId) {
+        this.socialAuthId = socialAuthId;
+    }
+
+    public static NaverSocialAuthUser from(SocialAuthId socialAuthId) {
+        return new NaverSocialAuthUser(socialAuthId);
+    }
+    //== 비즈니스 로직 ==//
+    //== 수정 메소드 ==//
+    //== 조회 메소드 ==//
+
+    @Override
+    public SocialAuthId getSocialAuthId() {
+        return socialAuthId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        NaverSocialAuthUser that = (NaverSocialAuthUser) o;
+        return Objects.equals(socialAuthId, that.socialAuthId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(socialAuthId);
+    }
+}

--- a/src/main/java/petalk/mvp/auth/domain/SocialAuthId.java
+++ b/src/main/java/petalk/mvp/auth/domain/SocialAuthId.java
@@ -1,0 +1,39 @@
+package petalk.mvp.auth.domain;
+
+/**
+ * 써드 파티 유저의 id를 나타내는 클래스입니다.
+ */
+public class SocialAuthId {
+
+    private String id;
+
+    //== 생성 메소드 ==//
+    private SocialAuthId(String id) {
+        this.id = id;
+    }
+
+    public static SocialAuthId from(String id) {
+        return new SocialAuthId(id);
+    }
+    //== 비즈니스 로직 ==//
+    //== 수정 메소드 ==//
+    //== 조회 메소드 ==//
+
+    public String getValue() {
+        return id;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof SocialAuthId) {
+            SocialAuthId other = (SocialAuthId) obj;
+            return id.equals(other.id);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+}

--- a/src/main/java/petalk/mvp/auth/domain/SocialAuthUser.java
+++ b/src/main/java/petalk/mvp/auth/domain/SocialAuthUser.java
@@ -1,0 +1,10 @@
+package petalk.mvp.auth.domain;
+
+/**
+ * 써드 파티 유저 인터페이스입니다.
+ *
+ */
+public interface SocialAuthUser {
+
+    SocialAuthId getSocialAuthId();
+}

--- a/src/main/java/petalk/mvp/auth/domain/SocialAuthenticator.java
+++ b/src/main/java/petalk/mvp/auth/domain/SocialAuthenticator.java
@@ -1,0 +1,9 @@
+package petalk.mvp.auth.domain;
+
+/**
+ * 소셜 인증 요청 인터페이스입니다.
+ */
+public interface SocialAuthenticator {
+
+    AccessToken getAccessToken(String code);
+}

--- a/src/main/java/petalk/mvp/auth/domain/User.java
+++ b/src/main/java/petalk/mvp/auth/domain/User.java
@@ -1,0 +1,67 @@
+package petalk.mvp.auth.domain;
+
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * 인증된 유저를 나타내는 클래스입니다.
+ */
+public class User {
+    private UserId id;
+    private UserAuthorities userAuthorities;
+
+    //== 생성 메소드 ==//
+    private User(UserId id, UserAuthorities userAuthorities) {
+        this.id = id;
+        this.userAuthorities = userAuthorities;
+    }
+
+    public static User existPetOwner(UUID id) {
+        return new User(UserId.from(id), UserAuthorities.petOwner());
+    }
+
+    public static User existVet(UUID id) {
+        return new User(UserId.from(id), UserAuthorities.vet());
+    }
+
+    //== 비즈니스 로직 ==//
+    //== 수정 메소드 ==//
+    //== 조회 메소드 ==//
+
+    public UserId getId() {
+        return id;
+    }
+
+    /**
+     * 인증된 유저의 id를 나타내는 클래스입니다.
+     */
+    public static class UserId {
+
+        private UUID id;
+
+        private UserId(UUID id) {
+            this.id = id;
+        }
+
+        public static UserId from(UUID id) {
+            return new UserId(id);
+        }
+
+        public UUID getValue() {
+            return id;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            UserId userId = (UserId) o;
+            return Objects.equals(id, userId.id);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(id);
+        }
+    }
+}

--- a/src/main/java/petalk/mvp/auth/domain/UserAuthorities.java
+++ b/src/main/java/petalk/mvp/auth/domain/UserAuthorities.java
@@ -1,0 +1,39 @@
+package petalk.mvp.auth.domain;
+
+/**
+ * 유저 권한을 나타내는 클래스입니다.
+ */
+public class UserAuthorities {
+
+    private Authority authority;
+
+    private UserAuthorities(Authority authority) {
+        this.authority = authority;
+    }
+
+    /**
+     * 반려인 권한을 생성합니다.
+     * @return 반려인 권한
+     */
+    public static UserAuthorities petOwner() {
+        return new UserAuthorities(Authority.PET_OWNER);
+    }
+
+    /**
+     * 수의사 권한을 생성합니다.
+     * @return 수의사 권한
+     */
+    public static UserAuthorities vet() {
+        return new UserAuthorities(Authority.VET);
+    }
+
+    /**
+     * 계정 권한을 의미합니다.
+     */
+    public enum Authority {
+        // 반려인을 의미합니다.
+        PET_OWNER,
+        // 수의사를 의미합니다.
+        VET
+    }
+}

--- a/src/main/java/petalk/mvp/auth/domain/UserSession.java
+++ b/src/main/java/petalk/mvp/auth/domain/UserSession.java
@@ -1,0 +1,83 @@
+package petalk.mvp.auth.domain;
+
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * 세션을 나타내는 클래스입니다.
+ *
+ */
+public class UserSession {
+
+    /**
+     * 세션 아이디입니다.
+     * 해당 클래스는 sesseionId를 통해 같은 클래스임을 비교합니다.
+     *
+     * @see #equals(Object)
+     * @see #hashCode()
+     */
+    private SessionId sessionId;
+
+    //== 생성 메소드 ==//
+    private UserSession(SessionId sessionId) {
+        this.sessionId = sessionId;
+    }
+
+    public static UserSession of(SessionId sessionId) {
+        return new UserSession(sessionId);
+    }
+    //== 비즈니스 로직 ==//
+    //== 수정 메소드 ==//
+    //== 조회 메소드 ==//
+
+    public SessionId getSessionId() {
+        return sessionId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        UserSession that = (UserSession) o;
+        return Objects.equals(sessionId, that.sessionId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(sessionId);
+    }
+
+
+    /**
+     * 세션의 id를 나타내는 클래스입니다.
+     */
+    public static class SessionId {
+
+        private UUID id;
+
+        private SessionId(UUID id) {
+            this.id = id;
+        }
+
+        public static SessionId from(UUID id) {
+            return new SessionId(id);
+        }
+
+        public UUID getValue() {
+            return id;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            SessionId sessionId = (SessionId) o;
+            return Objects.equals(id, sessionId.id);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(id);
+        }
+    }
+}


### PR DESCRIPTION
# 제목

소셜 회원 인증 서비스 도메인 추가

## 이슈
> 이슈 링크를 달아주세요.

#1 #6 

## 변경사항
> 이 PR의 모든 변경 사항을 적어주세요.

- 액세스 토큰 추가
- 소셜 로그인 인증기 추상화
- 네이버 소셜 로그인 인증기 추가
- gitignore 수정
  - out폴더에 대한 ignore을 최상단 out폴더에 대해서만 무시하도록 변경하였습니다
- 써드 파티 id 추가
- 써드 파티 유저 추상화
- 네이버 인증 유저 추가
- 유저 권한 추가
- 유저 추가
- 유저 세션 추가

## 테스트 결과
> 주요 변경 내용에 대한 스크린샷 또는 테스트 링크를 추가 해주세요.

<img width="1311" alt="image" src="https://github.com/pet-talk/mvp-server/assets/37677423/237d04de-8c28-4390-9431-0dd297ec6928">


## 영향 범위
> 이 PR이 영향을 주는 주요 기능에 대해 적어주세요.

## 기타 참고 사항
> 리뷰에 참고할 추가 내용이 있으면 기술 해주세요
