### PR TITLE
인증 도메인의 adapter 레이어에 카카오 소셜 로그인 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,8 @@ dependencies {
 	// guava 의존성 보유
 	implementation 'com.google.guava:guava:32.1.3-jre'
 
+	implementation 'commons-codec:commons-codec:1.16.0' // commons-codec 의존성 보유
+
 }
 
 tasks.named('bootBuildImage') {

--- a/src/main/java/petalk/mvp/core/MapperConfig.java
+++ b/src/main/java/petalk/mvp/core/MapperConfig.java
@@ -2,6 +2,7 @@ package petalk.mvp.core;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
+import org.apache.commons.codec.binary.Base64;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -25,5 +26,10 @@ public class MapperConfig {
     @Bean
     public ObjectMapper objectMapper() {
         return new ObjectMapper();
+    }
+
+    @Bean
+    public Base64 base64() {
+        return new Base64();
     }
 }

--- a/src/main/java/petalk/mvp/domain/auth/AuthUser.java
+++ b/src/main/java/petalk/mvp/domain/auth/AuthUser.java
@@ -24,13 +24,28 @@ public class AuthUser {
     }
 
     /**
-     * 기존 반려인 유저를 생성합니다.
-     * @param id 반려인 유저의 id
+     * 존재하는 반려인 유저를 생성합니다.
+     * @param id 유저 id
+     * @param socialInfo 소셜 정보
+     * @param nickname 닉네임
+     * @param authority 권한
+     * @param registrationDate 등록일
      * @return 반려인 유저
      */
     public static AuthUser exist(AuthUser.UserId id, UserSocialInfo socialInfo, String nickname, UserAuthority authority, LocalDateTime registrationDate) {
         return new AuthUser(id, socialInfo, nickname, UserAuthorities.from(authority), registrationDate);
     }
+
+    /**
+     * 새로운 반려인 유저를 생성합니다.
+     * @param email 이메일
+     * @param socialType 소셜 타입
+     * @param socialId 소셜 아이디
+     * @param socialName 소셜 이름
+     * @param nickname 닉네임
+     * @param registrationDate 등록일
+     * @return 반려인 유저
+     */
 
     public static AuthUser register(String email, SocialType socialType, SocialAuthId socialId, String socialName, String nickname, LocalDateTime registrationDate) {
         UserSocialInfo socialInfo = UserSocialInfo.register(email, socialType, socialId, socialName);

--- a/src/main/java/petalk/mvp/domain/auth/KakaoSocialAuthUser.java
+++ b/src/main/java/petalk/mvp/domain/auth/KakaoSocialAuthUser.java
@@ -1,0 +1,58 @@
+package petalk.mvp.domain.auth;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+/**
+ * 카카오 유저를 나타내는 클래스입니다.
+ *
+ */
+public class KakaoSocialAuthUser implements SocialAuthUser{
+    private SocialAuthId socialAuthId;
+    private String email;
+    private String nickname;
+    private SocialType socialType;
+
+    //== 생성 메소드 ==//
+
+    private KakaoSocialAuthUser(SocialAuthId socialAuthId, String email, String nickname, SocialType socialType) {
+        this.socialAuthId = socialAuthId;
+        this.email = email;
+        this.nickname = nickname;
+        this.socialType = socialType;
+    }
+
+    public static KakaoSocialAuthUser of(SocialAuthId socialAuthId, String email, String nickname) {
+        return new KakaoSocialAuthUser(socialAuthId, email, nickname, SocialType.KAKAO);
+    }
+    //== 비즈니스 로직 ==//
+    @Override
+    public AuthUser registerUser(LocalDateTime registrationDate) {
+        return AuthUser.register(this.email, this.socialType, this.socialAuthId, this.nickname, this.nickname, registrationDate);
+    }
+    //== 수정 메소드 ==//
+    //== 조회 메소드 ==//
+
+    @Override
+    public SocialAuthId getSocialId() {
+        return socialAuthId;
+    }
+
+    @Override
+    public SocialType getSocialType() {
+        return socialType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        KakaoSocialAuthUser that = (KakaoSocialAuthUser) o;
+        return Objects.equals(socialAuthId, that.socialAuthId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(socialAuthId);
+    }
+}

--- a/src/main/java/petalk/mvp/http/auth/adapter/LoadSocialUserAdapter.java
+++ b/src/main/java/petalk/mvp/http/auth/adapter/LoadSocialUserAdapter.java
@@ -11,25 +11,25 @@ import java.util.Optional;
 /**
  * 소셜 사용자 정보 로드 어댑터 클래스입니다.
  * <p>
- * 이 클래스는 LoadSocialUserPort 인터페이스의 구현입니다.
+ * 이 클래스는 LoadSocialUserPort 인터페이스의 구현입니다. <br>
  * 제공된 인증기를 활용하여 소셜 사용자 정보를 로드하는 역할을 합니다.
  */
 @PersistenceAdapter
 public class LoadSocialUserAdapter implements LoadSocialUserPort {
 
-    private final AccessTokenRequesterFactory accessTokenRequesterFactory;
-    private final ProfileRequesterFactory profileRequesterFactory;
+    private final ProfileKeyReaderFactory profileKeyReaderFactory;
+    private final ProfileReaderFactory profileReaderFactory;
 
 
-    public LoadSocialUserAdapter(AccessTokenRequesterFactory accessTokenRequesterFactory, ProfileRequesterFactory profileRequesterFactory) {
-        this.accessTokenRequesterFactory = accessTokenRequesterFactory;
-        this.profileRequesterFactory = profileRequesterFactory;
+    public LoadSocialUserAdapter(ProfileKeyReaderFactory profileKeyReaderFactory, ProfileReaderFactory profileReaderFactory) {
+        this.profileKeyReaderFactory = profileKeyReaderFactory;
+        this.profileReaderFactory = profileReaderFactory;
     }
 
     @Override
     public Optional<SocialAuthUser> loadSocialUser(AuthorizationCode code, SocialType socialType) {
-        SocialProfileKeyReader profileKeyReader = accessTokenRequesterFactory.getOauthTokenRequester(socialType);
-        SocialProfileReader profileRequester = profileRequesterFactory.getProfileRequester(socialType);
+        SocialProfileKeyReader profileKeyReader = profileKeyReaderFactory.getOauthTokenRequester(socialType);
+        SocialProfileReader profileRequester = profileReaderFactory.getProfileRequester(socialType);
 
         return profileKeyReader
                 .getKey(code)

--- a/src/main/java/petalk/mvp/http/auth/adapter/ProfileKeyReaderFactory.java
+++ b/src/main/java/petalk/mvp/http/auth/adapter/ProfileKeyReaderFactory.java
@@ -9,17 +9,17 @@ import java.util.List;
 
 
 /**
- * 소셜 액세스 토큰 http 요청자를 생성하는 팩토리 클래스입니다.
+ * 소셜 프로필 키 리더를 생성하는 팩토리 클래스입니다.
  * <p>
- * 제공 받은 Authenticator 를 통해 어떤 소셜 로그인인지 판단하여 해당 소셜 로그인에 맞는 GetSocialTokenRequester 를 반환합니다.
+ * 제공 받은 소셜 타입을 통해 어떤 소셜 로그인인지 판단하여 해당 소셜 로그인에 맞는 소셜 프로필 키 리더를 반환합니다.
  */
 @Component
-public class AccessTokenRequesterFactory {
+public class ProfileKeyReaderFactory {
 
     private final List<SocialProfileKeyReader> profileKeyReaders;
 
     @Autowired
-    public AccessTokenRequesterFactory(SocialProfileKeyReader... profileKeyReaders) {
+    public ProfileKeyReaderFactory(SocialProfileKeyReader... profileKeyReaders) {
         this.profileKeyReaders = Arrays.asList(profileKeyReaders);
     }
 

--- a/src/main/java/petalk/mvp/http/auth/adapter/ProfileReaderFactory.java
+++ b/src/main/java/petalk/mvp/http/auth/adapter/ProfileReaderFactory.java
@@ -8,17 +8,17 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * 소셜 프로필 http 요청자를 생성하는 팩토리 클래스입니다.
+ * 소셜 프로필 리더를 생성하는 팩토리 클래스입니다.
  *
- * 제공 받은 Authenticator 를 통해 어떤 소셜 로그인인지 판단하여 해당 소셜 로그인에 맞는 GetSocialProfileRequester 를 반환합니다.
+ * 제공 받은 SocialType을 통해 어떤 소셜 로그인인지 판단하여 해당 소셜 로그인에 맞는 소셜 프로필 리더를 반환합니다.
  */
 @Component
-public class ProfileRequesterFactory {
+public class ProfileReaderFactory {
 
     private final List<SocialProfileReader> socialProfileReaders;
 
     @Autowired
-    public ProfileRequesterFactory(SocialProfileReader... socialProfileReaders) {
+    public ProfileReaderFactory(SocialProfileReader... socialProfileReaders) {
         this.socialProfileReaders = Arrays.asList(socialProfileReaders);
     }
 

--- a/src/main/java/petalk/mvp/http/auth/request/KakaoIdTokenRequester.java
+++ b/src/main/java/petalk/mvp/http/auth/request/KakaoIdTokenRequester.java
@@ -1,0 +1,59 @@
+package petalk.mvp.http.auth.request;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+// import auth domain
+import petalk.mvp.domain.auth.AuthorizationCode;
+import petalk.mvp.domain.auth.SocialType;
+
+// import auth adapter
+import petalk.mvp.http.auth.adapter.SocialProfileKeyReader;
+import petalk.mvp.http.auth.adapter.SocialTokenResponse;
+
+import java.util.Optional;
+
+/**
+ * 카카오 id 토큰 http 요청 구현체입니다.
+ */
+@Component
+@Slf4j
+public class KakaoIdTokenRequester implements SocialProfileKeyReader {
+
+    private final KakaoTokenCommandBuilder tokenCommandBuilder;
+    private final RestTemplate restTemplate;
+    private final String TOKEN_URL;
+
+    public KakaoIdTokenRequester(
+            KakaoTokenCommandBuilder tokenCommandBuilder, RestTemplate restTemplate,
+            @Value("${value.social.kakao.url.token}") String tokenUrl) {
+        this.tokenCommandBuilder = tokenCommandBuilder;
+        this.restTemplate = restTemplate;
+        this.TOKEN_URL = tokenUrl;
+    }
+
+    @Override
+    public Optional<SocialTokenResponse> getKey(AuthorizationCode code) {
+        HttpEntity<MultiValueMap<String, String>> command = tokenCommandBuilder.generateCommand(code);
+
+        ResponseEntity<KakaoTokenResponse> responseEntity = restTemplate.postForEntity(TOKEN_URL, command, KakaoTokenResponse.class);
+
+        KakaoTokenResponse response = responseEntity.getBody();
+        log.debug("kakao token response: {}", response);
+
+        if (responseEntity.getStatusCode().is2xxSuccessful() && response != null) {
+            return Optional.of(response);
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean isCorrectType(SocialType type) {
+        return SocialType.KAKAO.equals(type);
+    }
+}

--- a/src/main/java/petalk/mvp/http/auth/request/KakaoProfile.java
+++ b/src/main/java/petalk/mvp/http/auth/request/KakaoProfile.java
@@ -1,0 +1,42 @@
+package petalk.mvp.http.auth.request;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.ToString;
+
+//auth domain import
+import petalk.mvp.domain.auth.KakaoSocialAuthUser;
+import petalk.mvp.domain.auth.SocialAuthId;
+import petalk.mvp.domain.auth.SocialAuthUser;
+
+//auth adapter import
+import petalk.mvp.http.auth.adapter.SocialProfile;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@ToString
+public class KakaoProfile implements SocialProfile {
+
+    private String id;
+    private String nickname;
+    private String profileImage;
+    private String email;
+
+    @JsonCreator
+    public KakaoProfile(
+            @JsonProperty("sub") String id,
+            @JsonProperty("nickname") String nickname,
+            @JsonProperty("picture") String profileImage,
+            @JsonProperty("email") String email) {
+        this.id = id;
+        this.nickname = nickname;
+        this.profileImage = profileImage;
+        //TODO 카카오에서 이메일을 제공하지 않는 경우가 있음. 이 경우에는 null이 들어옴. 이 경우에 대한 처리가 필요함.
+        this.email = email == null ? "kakao" : email;
+    }
+
+    @Override
+    public SocialAuthUser toSocialAuthUser() {
+        return KakaoSocialAuthUser.of(SocialAuthId.from(id), email, nickname);
+    }
+}

--- a/src/main/java/petalk/mvp/http/auth/request/KakaoProfileReader.java
+++ b/src/main/java/petalk/mvp/http/auth/request/KakaoProfileReader.java
@@ -1,0 +1,66 @@
+package petalk.mvp.http.auth.request;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.codec.binary.Base64;
+import org.springframework.stereotype.Component;
+import petalk.mvp.domain.auth.SocialType;
+
+// import auth adapter
+import petalk.mvp.http.auth.adapter.SocialProfile;
+import petalk.mvp.http.auth.adapter.SocialProfileReader;
+import petalk.mvp.http.auth.adapter.SocialTokenResponse;
+
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * 카카오 프로필을 불러오는 구현체입니다.
+ */
+@Component
+@Slf4j
+public class KakaoProfileReader implements SocialProfileReader {
+    private final ObjectMapper objectMapper;
+    private final Base64 base64;
+
+    public KakaoProfileReader(ObjectMapper objectMapper, Base64 base64) {
+        this.objectMapper = objectMapper;
+        this.base64 = base64;
+    }
+
+    @Override
+    public Optional<SocialProfile> getProfile(SocialTokenResponse tokenResponse) {
+        String key = tokenResponse.generateKey();
+
+        String profileStr = extractJson(key);
+
+        log.debug("kakao profile key: {}", profileStr);
+
+        try {
+            KakaoProfile kakaoProfile = objectMapper.readValue(profileStr, KakaoProfile.class);
+            return Optional.of(kakaoProfile);
+        } catch (Exception e) {
+            log.error("kakao profile parsing error", e);
+            return Optional.empty();
+        }
+    }
+    private String extractJson(String key) {
+        // base64 디코딩
+        String content = new String(base64.decode(key.getBytes()));
+        log.debug("kakao profile key decoding: {}", content);
+
+        // {"aud": ... } 형태의 JSON 문자열을 추출
+        Pattern pattern = Pattern.compile("\\{[^{}]*\"aud\":\"[^\"]*\"[^{}]*\\}");
+        Matcher matcher = pattern.matcher(content);
+        if (matcher.find()) {
+            return matcher.group(0); // Return the first match that looks like a JSON object
+        }
+        return null;
+    }
+
+    @Override
+    public boolean isCorrectType(SocialType type) {
+        return SocialType.KAKAO.equals(type);
+    }
+}

--- a/src/main/java/petalk/mvp/http/auth/request/KakaoTokenCommand.java
+++ b/src/main/java/petalk/mvp/http/auth/request/KakaoTokenCommand.java
@@ -1,0 +1,34 @@
+package petalk.mvp.http.auth.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+/**
+ * 카카오 액세스 토큰 요청 모델입니다.
+ */
+@Builder
+public class KakaoTokenCommand {
+
+    @JsonProperty("grant_type")
+    private String grantType;
+
+    @JsonProperty("client_id")
+    private String clientId;
+
+    @JsonProperty("client_secret")
+    private String clientSecret;
+
+    @JsonProperty("redirect_uri")
+    private String redirectUri;
+
+    @JsonProperty("code")
+    private String code;
+
+    public KakaoTokenCommand(String grantType, String clientId, String clientSecret, String redirectUri, String code) {
+        this.grantType = grantType;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.redirectUri = redirectUri;
+        this.code = code;
+    }
+}

--- a/src/main/java/petalk/mvp/http/auth/request/KakaoTokenCommandBuilder.java
+++ b/src/main/java/petalk/mvp/http/auth/request/KakaoTokenCommandBuilder.java
@@ -1,0 +1,52 @@
+package petalk.mvp.http.auth.request;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+//auth domain import
+import petalk.mvp.domain.auth.AuthorizationCode;
+
+/**
+ * 카카오 토큰 http 요청 커맨드 빌더입니다.
+ */
+@Component
+public class KakaoTokenCommandBuilder {
+
+    private final String clientId;
+    private final String redirectId;
+    private final String clientSecret;
+    private final String grantType;
+    private final MediaType CONTENT_TYPE = MediaType.APPLICATION_FORM_URLENCODED;
+
+
+    public KakaoTokenCommandBuilder(
+            @Value("${value.social.kakao.client_id}") String clientId,
+            @Value("${value.social.kakao.redirect}") String redirectId,
+            @Value("${value.social.kakao.client_secret}") String clientSecret,
+            @Value("${value.social.kakao.grant_type}") String grantType) {
+        this.clientId = clientId;
+        this.redirectId = redirectId;
+        this.clientSecret = clientSecret;
+        this.grantType = grantType;
+    }
+
+    public HttpEntity<MultiValueMap<String, String>> generateCommand(AuthorizationCode code) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(CONTENT_TYPE);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", grantType);
+        params.add("client_id", clientId);
+        params.add("client_secret", clientSecret);
+        params.add("redirect_uri", redirectId);
+        params.add("code", code.getValue());
+
+        return new HttpEntity<>(params, headers);
+
+    }
+}

--- a/src/main/java/petalk/mvp/http/auth/request/KakaoTokenResponse.java
+++ b/src/main/java/petalk/mvp/http/auth/request/KakaoTokenResponse.java
@@ -1,0 +1,64 @@
+package petalk.mvp.http.auth.request;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.ToString;
+
+//auth adapter import
+import petalk.mvp.http.auth.adapter.SocialTokenResponse;
+
+/**
+ * 카카오 서비스의 액세스 토큰을 나타냅니다.
+ */
+@ToString
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoTokenResponse implements SocialTokenResponse {
+    private String accessToken;
+    private String tokenType;
+    private String refreshToken;
+    private int expiresIn;
+    private String idToken;
+    private String refreshTokenExpiresIn;
+    private String scope;
+
+    @JsonCreator
+    public KakaoTokenResponse(
+            @JsonProperty("access_token") String accessToken,
+            @JsonProperty("token_type") String tokenType,
+            @JsonProperty("refresh_token") String refreshToken,
+            @JsonProperty("expires_in") String expiresIn,
+            @JsonProperty("id_token") String idToken,
+            @JsonProperty("refresh_token_expires_in") String refreshTokenExpiresIn,
+            @JsonProperty("scope") String scope) {
+        this.accessToken = accessToken;
+        this.tokenType = tokenType;
+        this.refreshToken = refreshToken;
+        this.expiresIn = (expiresIn != null) ? Integer.parseInt(expiresIn) :  0;
+        this.idToken = idToken;
+        this.refreshTokenExpiresIn = refreshTokenExpiresIn;
+        this.scope = scope;
+
+        this.validate();
+    }
+
+    public void validate() {
+        if (accessToken == null || accessToken.isBlank()) {
+            throw new IllegalArgumentException("accessToken is null or empty");
+        }
+        if (tokenType == null || tokenType.isBlank()) {
+            throw new IllegalArgumentException("tokenType is null or empty");
+        }
+        if (refreshToken == null || refreshToken.isBlank()) {
+            throw new IllegalArgumentException("refreshToken is null or empty");
+        }
+        if (expiresIn <= 0) {
+            throw new IllegalArgumentException("expiresIn is less than or equal to zero");
+        }
+    }
+
+    @Override
+    public String generateKey() {
+        return idToken;
+    }
+}

--- a/src/test/java/petalk/mvp/acceptance/auth/KakaoAuthenticateAcceptanceTest.java
+++ b/src/test/java/petalk/mvp/acceptance/auth/KakaoAuthenticateAcceptanceTest.java
@@ -1,0 +1,90 @@
+package petalk.mvp.acceptance.auth;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import petalk.mvp.acceptance.auth.apiTester.AuthenticateApiTester;
+import petalk.mvp.core.acceptance.utils.AbstractAcceptanceTest;
+import petalk.mvp.core.annotation.AcceptanceTest;
+
+
+@AcceptanceTest
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@DisplayName("카카오 인증 요청 인수 테스트")
+public class KakaoAuthenticateAcceptanceTest extends AbstractAcceptanceTest {
+
+    @Autowired
+    AuthenticateApiTester apiTester;
+
+    private String 소셜계정코드;
+
+    @BeforeEach
+    protected void setUp() {
+        소셜계정코드 = "code";
+    }
+
+    /**
+     * @when 인증 요청을 할 때
+     * @then 회원 인증이 가능하다.
+     */
+    @Test
+    @DisplayName("회원가입이 되어있지 않더라도 소셜 계정으로 인증 요청을 하면 회원 인증이 가능하다.")
+    void whenHaveSocialIdThenCanAuthenticate() {
+
+        //when
+        ExtractableResponse<Response> 인증_요청_응답 = apiTester.인증_요청("kakao", 소셜계정코드);
+
+        //then
+        apiTester.인증_성공(인증_요청_응답);
+    }
+
+    /**
+     * @when 인증 요청을 할 때
+     * @then 닉네임이 소셜계정 정보 기반으로 자동 설정된다.
+     */
+    @Test
+    @DisplayName("서비스 계정이 없다면 인증 요청을 할 때 닉네임이 자동으로 설정된다.")
+    void whenIdIsNotExistThenNicknameIsSetUpBySocialInfo() throws Exception {
+
+        //when
+        ExtractableResponse<Response> 인증_요청_응답 = apiTester.인증_요청("kakao", 소셜계정코드);
+
+        //then
+        apiTester.요청_닉네임_체크(인증_요청_응답);
+    }
+
+    /**
+     * @when 인증 요청을 할 때
+     * @then 응답에서 현재 계정의 권한과 id와 닉네임을 확인할 수 있다.
+     */
+    @Test
+    @DisplayName("계정이 존재한다면 인증 요청을 할 때 응답에서 현재 계정의 권한, id, 닉네임을 확인할 수 있다.")
+    void whenIdIsExistThenCanCheckAuthorityAndIdAndNickname() throws Exception {
+
+        //when
+        ExtractableResponse<Response> 인증_요청_응답 = apiTester.인증_요청("kakao", 소셜계정코드);
+
+        //then
+        apiTester.요청_아이디_권한_체크(인증_요청_응답);
+    }
+
+
+    /**
+     * @when 인증 요청을 할 때
+     * @then 응답에서 현재 요청의 세션 id을 확인할 수 있다.
+     */
+    @Test
+    @DisplayName("소셜 계정이 존재한다면 인증 요청을 할 때 응에서 현재 요청의 세션 id를 확인할 수 있다.")
+    void whenAuthenticateThenCanCheck() {
+
+        //when
+        ExtractableResponse<Response> 인증_요청_응답 = apiTester.인증_요청("kakao", 소셜계정코드);
+
+        //then
+        apiTester.요청_세션_체크(인증_요청_응답);
+    }
+}

--- a/src/test/java/petalk/mvp/http/auth/adapter/ProfileKeyReaderFactoryTest.java
+++ b/src/test/java/petalk/mvp/http/auth/adapter/ProfileKeyReaderFactoryTest.java
@@ -16,7 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @UnitTest
 @DisplayName("소셜 액세스 토큰 http 요청자 팩토리 테스트")
-class AccessTokenRequesterFactoryTest {
+class ProfileKeyReaderFactoryTest {
 
     private final RestTemplate restTemplate = new RestTemplate();
     private final Gson gson = new Gson();
@@ -33,7 +33,7 @@ class AccessTokenRequesterFactoryTest {
             new GoogleTokenCommandBuilder(CLIENT_ID, REDIRECT_ID, CLIENT_SECRET, GRANT_TYPE);
     private final NaverTokenRequester getNaverTokenRequester = new NaverTokenRequester(tokenBuilder, restTemplate);
     private final GoogleTokenRequester getGoogleTokenRequester = new GoogleTokenRequester(googleTokenCommandBuilder, restTemplate, gson, URL);
-    private final AccessTokenRequesterFactory accessTokenRequesterFactory = new AccessTokenRequesterFactory(getNaverTokenRequester, getGoogleTokenRequester);
+    private final ProfileKeyReaderFactory profileKeyReaderFactory = new ProfileKeyReaderFactory(getNaverTokenRequester, getGoogleTokenRequester);
 
     /**
      * @given 소셜 인증 서비스가 네이버라면
@@ -47,7 +47,7 @@ class AccessTokenRequesterFactoryTest {
         SocialType type = SocialType.NAVER;
 
         //when
-        SocialProfileKeyReader oauthTokenRequester = accessTokenRequesterFactory.getOauthTokenRequester(type);
+        SocialProfileKeyReader oauthTokenRequester = profileKeyReaderFactory.getOauthTokenRequester(type);
 
         //then
         assertThat(oauthTokenRequester.isCorrectType(type)).isTrue();
@@ -65,7 +65,7 @@ class AccessTokenRequesterFactoryTest {
         SocialType type = SocialType.GOOGLE;
 
         //when
-        SocialProfileKeyReader oauthTokenRequester = accessTokenRequesterFactory.getOauthTokenRequester(type);
+        SocialProfileKeyReader oauthTokenRequester = profileKeyReaderFactory.getOauthTokenRequester(type);
 
         //then
         assertThat(oauthTokenRequester.isCorrectType(type)).isTrue();

--- a/src/test/java/petalk/mvp/http/auth/adapter/ProfileReaderFactoryTest.java
+++ b/src/test/java/petalk/mvp/http/auth/adapter/ProfileReaderFactoryTest.java
@@ -16,14 +16,14 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @UnitTest
 @DisplayName("소셜 프로필 http 요청자 팩토리 테스트")
-class ProfileRequesterFactoryTest {
+class ProfileReaderFactoryTest {
 
     private final RestTemplate restTemplate = new RestTemplate();
     private final Gson gson = new Gson();
     private final String URL = "url";
     private final NaverProfileRequester getNaverProfileRequester = new NaverProfileRequester(restTemplate, URL);
     private final GoogleProfileRequester getGoogleProfileRequester = new GoogleProfileRequester(restTemplate, gson, URL);
-    private final ProfileRequesterFactory profileRequesterFactory = new ProfileRequesterFactory(getNaverProfileRequester, getGoogleProfileRequester);
+    private final ProfileReaderFactory profileReaderFactory = new ProfileReaderFactory(getNaverProfileRequester, getGoogleProfileRequester);
 
 
     /**
@@ -38,7 +38,7 @@ class ProfileRequesterFactoryTest {
         SocialType type = SocialType.NAVER;
 
         //when
-        SocialProfileReader oauthTokenRequester = profileRequesterFactory.getProfileRequester(type);
+        SocialProfileReader oauthTokenRequester = profileReaderFactory.getProfileRequester(type);
 
         //then
         assertThat(oauthTokenRequester.isCorrectType(type)).isTrue();


### PR DESCRIPTION
# 제목
인증 도메인의 adapter 레이어에 카카오 소셜 로그인 기능 추가

## 이슈
> 이슈 링크를 달아주세요.

#1 

## 변경사항
> 이 PR의 모든 변경 사항을 적어주세요.

## 테스트 결과
> 주요 변경 내용에 대한 스크린샷 또는 테스트 링크를 추가 해주세요.

<img width="602" alt="image" src="https://github.com/pet-talk/mvp-server/assets/37677423/178728bb-482a-4af9-8d03-0e6afa3e65f0">


## 영향 범위
> 이 PR이 영향을 주는 주요 기능에 대해 적어주세요.

## 기타 참고 사항
> 리뷰에 참고할 추가 내용이 있으면 기술 해주세요
